### PR TITLE
Improve performance of 1m entities example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .task
 .dist
 .tmp
+*.exe
+*out*

--- a/pkgs/gomp/ecs/component.go
+++ b/pkgs/gomp/ecs/component.go
@@ -105,6 +105,10 @@ func (c *WorldComponents[T]) All() iter.Seq2[EntityID, *T] {
 	return c.instances.All
 }
 
+func (c *WorldComponents[T]) AllData() iter.Seq[*T] {
+	return c.instances.AllData
+}
+
 // To use more threads we need to prespawn goroutines for each component
 // var threads = runtime.NumCPU() * 2
 

--- a/pkgs/gomp/ecs/component_test.go
+++ b/pkgs/gomp/ecs/component_test.go
@@ -1,0 +1,181 @@
+/*
+This Source Code Form is subject to the terms of the Mozilla
+Public License, v. 2.0. If a copy of the MPL was not distributed
+with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+package ecs
+
+import (
+	"image/color"
+	"math/rand"
+	"testing"
+)
+
+type pixel struct {
+	x      int32
+	y      int32
+	hp     int32
+	color  color.RGBA
+	breath bool
+}
+
+var pixelComponentType = CreateComponent[pixel]()
+
+// Commonly used functions in both benchmarks.
+func PrepareWorld(description string, system System) *World {
+	world := New(description)
+
+	world.RegisterComponentTypes(
+		&pixelComponentType,
+	)
+	world.RegisterSystems().Parallel(
+		system,
+	)
+
+	return &world
+}
+
+func InitPixelComponent(pixelComponent *WorldComponents[pixel], world *World) {
+	*pixelComponent = pixelComponentType.Instances(world)
+	determRand := rand.New(rand.NewSource(42))
+
+	for i := range 1000 {
+		for j := range 1000 {
+			newPixel := world.CreateEntity("Pixel")
+
+			randomGreen := uint8(135 / (determRand.Intn(10) + 1))
+			randomBlue := uint8(135 / (determRand.Intn(10) + 1))
+
+			randomColor := color.RGBA{
+				G: randomGreen,
+				B: randomBlue,
+				A: 255,
+			}
+			pixelComponent.Set(newPixel, pixel{
+				x:     int32(j),
+				y:     int32(i),
+				hp:    100,
+				color: randomColor,
+			})
+		}
+	}
+}
+
+type pixelSystem struct {
+	pixelComponent WorldComponents[pixel]
+}
+
+func (s *pixelSystem) Init(world *World) {
+	InitPixelComponent(&s.pixelComponent, world)
+}
+
+func (s *pixelSystem) Destroy(world *World) {}
+
+func (s *pixelSystem) Run(world *World) {
+	for pixel := range s.pixelComponent.AllData() {
+		// Note: was not extracted to separate function to simulate
+		// real-world interaction between range loop and inner code.
+		color := &pixel.color
+
+		if pixel.breath {
+			if color.G < 135 {
+				color.G++
+			} else {
+				pixel.hp++
+			}
+			if color.B < 135 {
+				color.B++
+			} else {
+				pixel.hp++
+			}
+		} else {
+			if color.G > 0 {
+				color.G--
+			} else {
+				pixel.hp--
+			}
+			if color.B > 0 {
+				color.B--
+			} else {
+				pixel.hp--
+			}
+		}
+
+		if pixel.hp <= 0 {
+			pixel.breath = true
+		} else if pixel.hp >= 100 {
+			pixel.breath = false
+		}
+	}
+}
+
+// Direct call iteration type
+type pixelSystemDirectCall struct {
+	pixelComponent WorldComponents[pixel]
+}
+
+func (s *pixelSystemDirectCall) Init(world *World) {
+	InitPixelComponent(&s.pixelComponent, world)
+}
+
+func (s *pixelSystemDirectCall) Destroy(world *World) {}
+
+func (s *pixelSystemDirectCall) Run(world *World) {
+	s.pixelComponent.AllData()(func(pixel *pixel) bool {
+		color := &pixel.color
+
+		if pixel.breath {
+			if color.G < 135 {
+				color.G++
+			} else {
+				pixel.hp++
+			}
+			if color.B < 135 {
+				color.B++
+			} else {
+				pixel.hp++
+			}
+		} else {
+			if color.G > 0 {
+				color.G--
+			} else {
+				pixel.hp--
+			}
+			if color.B > 0 {
+				color.B--
+			} else {
+				pixel.hp--
+			}
+		}
+
+		if pixel.hp <= 0 {
+			pixel.breath = true
+		} else if pixel.hp >= 100 {
+			pixel.breath = false
+		}
+		return true
+	})
+}
+
+// Note: amount of memory allocated changes between tests even with deterministic rand.
+// Observed range 918063 B/op - 1108007 B/op
+func BenchmarkRangeIteration(b *testing.B) {
+	b.ReportAllocs()
+	world := PrepareWorld("range iteration", new(pixelSystem))
+
+	for range b.N {
+		world.RunSystems()
+	}
+}
+
+// Note: amount of memory allocated changes between tests even with deterministic rand.
+// Observed range 868437 B/op - 1047789 B/op
+func BenchmarkDirectCallIteration(b *testing.B) {
+	b.ReportAllocs()
+	world := PrepareWorld("direct call iteration", new(pixelSystemDirectCall))
+
+	for range b.N {
+		world.RunSystems()
+	}
+}

--- a/pkgs/gomp/ecs/sparse-set.go
+++ b/pkgs/gomp/ecs/sparse-set.go
@@ -64,11 +64,19 @@ func (s *SparseSet[TData, TKey]) All(yield func(TKey, *TData) bool) {
 	var indexBuffer = s.denseIndex.buffer
 	var denseData = s.denseData
 
-	for i, v := range denseData.All {
-		if !yield(indexBuffer[i.page].data[i.local], v) {
+	for i, value := range denseData.All {
+		key := indexBuffer[i.page].data[i.local]
+		if !yield(key, value) {
 			return
 		}
 	}
+}
+
+func (s *SparseSet[TData, TKey]) AllData(yield func(*TData) bool) {
+	var denseData = s.denseData
+	denseData.All(func(i ChunkArrayIndex, value *TData) bool {
+		return yield(value)
+	})
 }
 
 func (s *SparseSet[TData, TKey]) SoftDelete(id TKey) {


### PR DESCRIPTION
This change enabled me to actually get to stable 60 tps / 60 fps (from 20 fps before) on my potato pc without changing core behavior.

![image](https://github.com/user-attachments/assets/ef22e226-39a7-4ea3-8890-859a2a9f3643)

Main ideas behind changes:
- use more compact pixel structure to have less cache misses
- use separate functions AllData for situations where we dont need index, and only interested in all values.
- stop usage of range over iterator, but make direct call to it with lamba as argument (this in particular gave great performance boost)
- use direct (although unsafe) pointer cast to assign ARGB values of color type to [4]byte image slice

Additionally:
- adds test for microbenchmarking iterator vs callback style of traversing elements of system
- adds *out* *.exe to git ignore to prevent bench results by accident
